### PR TITLE
Restructure trial matcher from sequential patient processing to global

### DIFF
--- a/src/trialmesh/__init__.py
+++ b/src/trialmesh/__init__.py
@@ -1,1 +1,2 @@
 # src/trialmesh/__init__.py
+__version__ = "1.0.0"


### PR DESCRIPTION
feat: implement cross-patient batching for vLLM efficiency gains

Restructure trial matcher from sequential patient processing to global 
cross-patient batching. Instead of processing patients individually with 
small trial batches, collect all patient-trial pairs and process in 3 
massive batches across the entire cohort.

Key changes:
- Replace per-patient sequential processing with global batch collection
- Process exclusion/inclusion/scoring in mega-batches (256-512 pairs)
- Maximize vLLM efficiency by hitting optimal batch size sweet spots
- Preserve all existing filtering logic and error handling
- Maintain backward compatibility with legacy methods

Performance impact:
- 7% improvement observed on development hardware (batch_size=28)
- Reduces hundreds of small LLM calls to 3 massive efficient batches

